### PR TITLE
Windowsのコマンドプロンプトウィンドウを抑止する設定を追加

### DIFF
--- a/rust/src/sdl2/src/main.rs
+++ b/rust/src/sdl2/src/main.rs
@@ -1,3 +1,8 @@
+// Windowsのコマンドプロンプトウィンドウを抑止
+// - debug   ウィンドウを出す
+// - release ウィンドウを抑止する
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+
 use sdl2::event::Event;
 use sdl2::keyboard::Keycode;
 use sdl2::pixels::Color;


### PR DESCRIPTION
## 概要

#6 の実装だと成果物のexeファイルを実行した際にコマンドプロンプトウィンドウが出てきてしまうため、ウィンドウを抑止するための記述を追加した。